### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jivanvl


### PR DESCRIPTION
As part of the process of publishing this as a public repo, CODEOWNERS is necessary to allow for external contributions