### PR TITLE
Updates docs on how to install Ghostty

### DIFF
--- a/full-mac-os-setup.md
+++ b/full-mac-os-setup.md
@@ -15,6 +15,7 @@ Most of the things listed in here are based on a note that I have on my Obsidian
   - [Go](https://go.dev/)
   - [Rust](https://www.rust-lang.org/)
   - [Little Snitch](https://obdev.at/products/littlesnitch/index.html)
+  - [Ghostty](https://ghostty.org)
 - Manual settings to change
   - System Preferences:
     - Accessibility > Display > Reduce Motion

--- a/roles/postbrew/tasks/main.yml
+++ b/roles/postbrew/tasks/main.yml
@@ -2,8 +2,3 @@
   command: corepack enable
   tags:
     - node
-
-- name: Install Kitty terminal
-  command: curl -L https://sw.kovidgoyal.net/kitty/installer.sh | sh /dev/stdin
-  tags:
-    - terminal


### PR DESCRIPTION
This removes kitty from the dependencies, terminal installation is done manually for now

Thank you Kitty